### PR TITLE
fix: return empty list instead of null in AssayService

### DIFF
--- a/src/main/java/no/metatrack/server/assay/AssayService.java
+++ b/src/main/java/no/metatrack/server/assay/AssayService.java
@@ -99,7 +99,7 @@ public class AssayService {
             assay.addSample(sample.get());
         }
 
-        if (errors.isEmpty()) return null;
+        if (errors.isEmpty()) return List.of();
 
         return errors;
     }
@@ -118,7 +118,7 @@ public class AssayService {
             assay.removeSample(sample.get());
         }
 
-        if (errors.isEmpty()) return null;
+        if (errors.isEmpty()) return List.of();
 
         return errors;
     }


### PR DESCRIPTION
When no errors occurred, the method returned null which caused a 204 No Content response. This resulted in a JSON parse error on the client, preventing the UI from updating after adding or removing samples from an assay.